### PR TITLE
Adding Array<T> support for @QueryParam

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ class TodoListController {
 `@QueryParam` allows injection of query parameter in your endpoint handler methods.
 `@QueryParam` parameters are required by default, meaning that if an `@Endpoint` method expects a given
  `@QueryParam` and the request received does not contain the query param expected, the handler will not be triggered.
+ Supports all the primitive Kotlin types + Arrays.
 
  In the example below, if a `GET /todo-lists` request is received without the expected _name_ query param
 `fetchTodoListForName` will not be triggered and Lamblin will return a _404_.

--- a/lamblin-core/src/main/kotlin/com/lamblin/core/extract/EndpointParamValueInjector.kt
+++ b/lamblin-core/src/main/kotlin/com/lamblin/core/extract/EndpointParamValueInjector.kt
@@ -24,7 +24,13 @@ internal interface EndpointParamValueInjector {
         paramAnnotationMappedNameToParam: Map<String, KParameter>
     ): Map<String, Any?>
 
-    fun castParamToRequiredType(paramType: KClass<*>?, paramValue: Any) = when (paramType) {
+    fun castParamToRequiredType(paramType: KClass<*>?, paramValue: Any) = when {
+        paramValue is Array<*> -> handleMultiValueParam(paramType, paramValue)
+        else -> handleSingleValueParam(paramType, paramValue)
+    }
+
+    fun handleSingleValueParam(paramType: KClass<*>?, paramValue: Any) = when(paramType) {
+        // Primitive types
         Byte::class -> (paramValue as String).toByte()
         Short::class -> (paramValue as String).toShort()
         Int::class -> (paramValue as String).toInt()
@@ -33,6 +39,42 @@ internal interface EndpointParamValueInjector {
         Float::class -> (paramValue as String).toFloat()
         Char::class -> (paramValue as String)[0]
         Boolean::class -> (paramValue as String).toBoolean()
+
+        // Array types
+        Array<Byte>::class -> byteArrayOf((paramValue as String).toByte())
+        Array<Short>::class -> shortArrayOf((paramValue as String).toShort())
+        Array<Int>::class -> intArrayOf((paramValue as String).toInt())
+        Array<Long>::class -> longArrayOf((paramValue as String).toLong())
+        Array<Float>::class -> floatArrayOf((paramValue as String).toFloat())
+        Array<Double>::class -> doubleArrayOf((paramValue as String).toDouble())
+        Array<Char>::class -> charArrayOf((paramValue as String)[0])
+        Array<Boolean>::class -> booleanArrayOf((paramValue as String).toBoolean())
+
+        else -> paramValue
+    }
+
+    fun handleMultiValueParam(paramType: KClass<*>?, paramValue: Array<*>) = when(paramType) {
+        // Primitive types
+        Byte::class -> (paramValue.first() as String).toByte()
+        Short::class -> (paramValue.first() as String).toShort()
+        Int::class -> (paramValue.first() as String).toInt()
+        Long::class -> (paramValue.first() as String).toLong()
+        Double::class -> (paramValue.first() as String).toDouble()
+        Float::class -> (paramValue.first() as String).toFloat()
+        Char::class -> (paramValue.first() as String)[0]
+        Boolean::class -> (paramValue.first() as String).toBoolean()
+        String::class -> paramValue.first() as String
+
+        // Array types
+        Array<Byte>::class -> paramValue.map { (it as String).toByte() }.toByteArray()
+        Array<Short>::class -> paramValue.map { (it as String).toShort() }.toShortArray()
+        Array<Int>::class -> paramValue.map { (it as String).toInt() }.toIntArray()
+        Array<Long>::class -> paramValue.map { (it as String).toLong() }.toLongArray()
+        Array<Float>::class -> paramValue.map { (it as String).toFloat() }.toFloatArray()
+        Array<Double>::class -> paramValue.map { (it as String).toDouble() }.toDoubleArray()
+        Array<Char>::class -> paramValue.map { (it as String)[0] }.toCharArray()
+        Array<Boolean>::class -> paramValue.map { (it as String).toBoolean() }.toBooleanArray()
+
         else -> paramValue
     }
 }

--- a/lamblin-core/src/test/kotlin/core/extract/EndpointParamValueInjectorTest.kt
+++ b/lamblin-core/src/test/kotlin/core/extract/EndpointParamValueInjectorTest.kt
@@ -72,4 +72,103 @@ class EndpointParamValueInjectorTest {
 
         assertThat(value).isEqualTo(true)
     }
+
+    @Test
+    fun `should cast multivavalue to byte array and primitive`() {
+        val valueArray = endpointParamValueInjector.castParamToRequiredType(Array<Byte>::class, arrayOf("1", "2"))
+
+        assertThat(valueArray).isEqualTo(byteArrayOf(1, 2))
+
+        val valuePrimitive = endpointParamValueInjector.castParamToRequiredType(Byte::class, arrayOf("1"))
+
+        assertThat(valuePrimitive).isEqualTo(1.toByte())
+    }
+
+    @Test
+    fun `should cast multivavalue to short array and primitive`() {
+        val valueArray = endpointParamValueInjector.castParamToRequiredType(Array<Short>::class, arrayOf("1", "2"))
+
+        assertThat(valueArray).isEqualTo(shortArrayOf(1, 2))
+
+        val valuePrimitive = endpointParamValueInjector.castParamToRequiredType(Short::class, arrayOf("1"))
+
+        assertThat(valuePrimitive).isEqualTo(1.toShort())
+    }
+
+    @Test
+    fun `should cast multivavalue to int array and primitive`() {
+        val valueArray = endpointParamValueInjector.castParamToRequiredType(Array<Int>::class, arrayOf("1", "2"))
+
+        assertThat(valueArray).isEqualTo(intArrayOf(1, 2))
+
+        val valuePrimitive = endpointParamValueInjector.castParamToRequiredType(Int::class, arrayOf("1"))
+
+        assertThat(valuePrimitive).isEqualTo(1)
+    }
+
+    @Test
+    fun `should cast multivavalue to long array and primitive`() {
+        val valueArray = endpointParamValueInjector.castParamToRequiredType(Array<Long>::class, arrayOf("1", "2"))
+
+        assertThat(valueArray).isEqualTo(longArrayOf(1, 2))
+
+        val valuePrimitive = endpointParamValueInjector.castParamToRequiredType(Long::class, arrayOf("1"))
+
+        assertThat(valuePrimitive).isEqualTo(1L)
+    }
+
+    @Test
+    fun `should cast multivavalue to double array and primitive`() {
+        val valueArray = endpointParamValueInjector.castParamToRequiredType(Array<Double>::class, arrayOf("1.2", "2.1"))
+
+        assertThat(valueArray).isEqualTo(doubleArrayOf(1.2, 2.1))
+
+        val valuePrimitive = endpointParamValueInjector.castParamToRequiredType(Double::class, arrayOf("1.2"))
+
+        assertThat(valuePrimitive).isEqualTo(1.2)
+    }
+
+    @Test
+    fun `should cast multivavalue to float array and primitive`() {
+        val valueArray = endpointParamValueInjector.castParamToRequiredType(Array<Float>::class, arrayOf("1.2", "2.1"))
+
+        assertThat(valueArray).isEqualTo(floatArrayOf(1.2f, 2.1f))
+
+        val valuePrimitive = endpointParamValueInjector.castParamToRequiredType(Float::class, arrayOf("1.2"))
+
+        assertThat(valuePrimitive).isEqualTo(1.2f)
+    }
+
+    @Test
+    fun `should cast multivavalue to char array and primitive`() {
+        val valueArray = endpointParamValueInjector.castParamToRequiredType(Array<Char>::class, arrayOf("a", "b"))
+
+        assertThat(valueArray).isEqualTo(charArrayOf('a', 'b'))
+
+        val valuePrimitive = endpointParamValueInjector.castParamToRequiredType(Char::class, arrayOf("a"))
+
+        assertThat(valuePrimitive).isEqualTo('a')
+    }
+
+    @Test
+    fun `should cast multivavalue to boolean array and primitive`() {
+        val valueArray = endpointParamValueInjector.castParamToRequiredType(Array<Boolean>::class, arrayOf("true", "false"))
+
+        assertThat(valueArray).isEqualTo(booleanArrayOf(true, false))
+
+        val valuePrimitive = endpointParamValueInjector.castParamToRequiredType(Boolean::class, arrayOf("true"))
+
+        assertThat(valuePrimitive).isEqualTo(true)
+    }
+
+    @Test
+    fun `should cast multivavalue to string array and primitive`() {
+        val valueArray = endpointParamValueInjector.castParamToRequiredType(Array<String>::class, arrayOf("foo", "bar"))
+
+        assertThat(valueArray).isEqualTo(arrayOf("foo", "bar"))
+
+        val valuePrimitive = endpointParamValueInjector.castParamToRequiredType(String::class, arrayOf("foo"))
+
+        assertThat(valuePrimitive).isEqualTo("foo")
+    }
 }

--- a/lamblin-example/lamblin-java-lambda/pom.xml
+++ b/lamblin-example/lamblin-java-lambda/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>lamblin-example</artifactId>
         <groupId>org.lamblin</groupId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/lamblin-example/lamblin-kotlin-lambda/pom.xml
+++ b/lamblin-example/lamblin-kotlin-lambda/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>lamblin-example</artifactId>
         <groupId>org.lamblin</groupId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/lamblin-example/pom.xml
+++ b/lamblin-example/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>lamblin-parent</artifactId>
         <groupId>org.lamblin</groupId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/lamblin-integration-test/lamblin-integration-test-common/pom.xml
+++ b/lamblin-integration-test/lamblin-integration-test-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>lamblin-integration-test</artifactId>
         <groupId>org.lamblin</groupId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/lamblin-integration-test/lamblin-integration-test-common/src/main/kotlin/com/lamblin/it/model/Endpoints.kt
+++ b/lamblin-integration-test/lamblin-integration-test-common/src/main/kotlin/com/lamblin/it/model/Endpoints.kt
@@ -9,6 +9,7 @@ package com.lamblin.it.model
 const val CUSTOM_STATUS_CODE_GET_ENDPOINT = "/get/custom-status-code"
 const val SIMPLE_GET_ENDPOINT = "/get/simple"
 const val QUERY_PARAM_GET_ENDPOINT = "/get/query-param"
+const val QUERY_PARAM_MULTI_KEY_GET_ENDPOINT = "/get/query-param-multi-key"
 const val QUERY_PARAM_DEFAULT_VALUE_GET_ENDPOINT = "/get/query-param/default-value"
 const val SINGLE_PATH_PARAM_GET_ENDPOINT = "/get/path/{$PATH_PARAM_1}"
 const val MULTI_PATH_PARAM_GET_ENDPOINT = "/get/path/{$PATH_PARAM_1}/foo/{$PATH_PARAM_2}"

--- a/lamblin-integration-test/lamblin-integration-test-java/pom.xml
+++ b/lamblin-integration-test/lamblin-integration-test-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lamblin-integration-test</artifactId>
         <groupId>org.lamblin</groupId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>lamblin-integration-test-java</artifactId>

--- a/lamblin-integration-test/lamblin-integration-test-kotlin/pom.xml
+++ b/lamblin-integration-test/lamblin-integration-test-kotlin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>lamblin-integration-test</artifactId>
         <groupId>org.lamblin</groupId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/lamblin-integration-test/lamblin-integration-test-kotlin/src/test/kotlin/com/lamblin/it/GetControllerIntegrationTest.kt
+++ b/lamblin-integration-test/lamblin-integration-test-kotlin/src/test/kotlin/com/lamblin/it/GetControllerIntegrationTest.kt
@@ -49,6 +49,16 @@ class GetControllerIntegrationTest {
     }
 
     @Test
+    fun `should handle GET requests with multiple query params which have the same key`() {
+        val queryParamValue1 = "value1"
+        val queryParamValue2 = "value2"
+
+        runRequestAndVerifyResponse(
+            { GetControllerClient.callMultiKeyQueryParamEndpoint(queryParamValue1, queryParamValue2) },
+            "$QUERY_PARAM_MULTI_KEY_GET_ENDPOINT-$queryParamValue1,$queryParamValue2")
+    }
+
+    @Test
     fun `should handle GET requests with single path param`() {
         val pathParamValue = "value"
 

--- a/lamblin-integration-test/lamblin-integration-test-kotlin/src/test/kotlin/com/lamblin/it/client/GetControllerClient.kt
+++ b/lamblin-integration-test/lamblin-integration-test-kotlin/src/test/kotlin/com/lamblin/it/client/GetControllerClient.kt
@@ -14,6 +14,7 @@ import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
+import retrofit2.http.Url
 import java.util.concurrent.TimeUnit
 
 object GetControllerClient {
@@ -42,6 +43,10 @@ object GetControllerClient {
     fun callMultiQueryParamEndpoint(queryParam1: String, queryParam2: String) =
         client.callMultiQueryParamEndpoint(queryParam1, queryParam2).execute()
 
+    fun callMultiKeyQueryParamEndpoint(queryParamValue1: String, queryParamValue2: String) =
+        client.callMultiKeyQueryParamEndpoint(
+            "${getServerBaseUrl()}$QUERY_PARAM_MULTI_KEY_GET_ENDPOINT?$QUERY_PARAM_1=$queryParamValue1&$QUERY_PARAM_1=$queryParamValue2").execute()
+
     fun callSinglePathParamEndpoint(pathParam: String) = client.callSinglePathParamEndpoint(pathParam).execute()
 
     fun callMultiPathParamEndpoint(pathParam1: String, pathParam2: String) =
@@ -69,6 +74,10 @@ object GetControllerClient {
         fun callMultiQueryParamEndpoint(
             @Query(QUERY_PARAM_1) queryParam1: String,
             @Query(QUERY_PARAM_2) queryParam2: String): Call<ResponseEntity>
+
+        @GET
+        fun callMultiKeyQueryParamEndpoint(
+            @Url url:String): Call<ResponseEntity>
 
         @GET(QUERY_PARAM_DEFAULT_VALUE_GET_ENDPOINT)
         fun callQueryParamDefaultValueEndpoint(): Call<ResponseEntity>

--- a/lamblin-integration-test/lamblin-integration-test-kotlin/src/test/kotlin/com/lamblin/it/controller/GetController.kt
+++ b/lamblin-integration-test/lamblin-integration-test-kotlin/src/test/kotlin/com/lamblin/it/controller/GetController.kt
@@ -41,6 +41,14 @@ class GetController {
         return HttpResponse.ok(ResponseEntity("$QUERY_PARAM_GET_ENDPOINT-$queryParam1,$queryParam2"))
     }
 
+    @Endpoint(QUERY_PARAM_MULTI_KEY_GET_ENDPOINT, method = HttpMethod.GET)
+    fun multipleQueryParamTest(
+        @QueryParam(QUERY_PARAM_1) queryParamValues: Array<String>): HttpResponse<ResponseEntity> {
+
+        return HttpResponse.ok(ResponseEntity("$QUERY_PARAM_MULTI_KEY_GET_ENDPOINT-${queryParamValues[0]},${queryParamValues[1]}"))
+    }
+
+
     @Endpoint(SINGLE_PATH_PARAM_GET_ENDPOINT, method = HttpMethod.GET)
     fun singlePathParamPath(
         @PathParam(PATH_PARAM_1) pathParam: String

--- a/lamblin-integration-test/pom.xml
+++ b/lamblin-integration-test/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>lamblin-parent</artifactId>
     <groupId>org.lamblin</groupId>
-    <version>0.2.4-SNAPSHOT</version>
+    <version>0.2.5-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/lamblin-local-runner/src/main/kotlin/com/lamblin/local/runner/LamblinDelegator.kt
+++ b/lamblin-local-runner/src/main/kotlin/com/lamblin/local/runner/LamblinDelegator.kt
@@ -49,7 +49,8 @@ class LamblinDelegator(
     private fun createRequestEvent(context: Context) = APIGatewayProxyRequestEvent().apply {
         httpMethod = context.method()
         path = context.path()
-        queryStringParameters = context.queryParamMap().mapValues { it.value[0] }
+        queryStringParameters = context.queryParamMap().mapValues { it.value.first() }
+        multiValueQueryStringParameters = context.queryParamMap()
         body = context.body()
         headers = context.headerMap()
     }

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <main.class>com.lamblin.core.Lamblin</main.class>
 
-        <aws-lambda-java-events.version>2.2.2</aws-lambda-java-events.version>
+        <aws-lambda-java-events.version>2.2.6</aws-lambda-java-events.version>
         <aws-lambda-java-sdk.version>1.11.405</aws-lambda-java-sdk.version>
         <jackson-databind.version>2.9.6</jackson-databind.version>
         <logback-classic.version>1.2.3</logback-classic.version>


### PR DESCRIPTION
Adding multikey support for @QueryParam - allowing multiple query params to have the same key.